### PR TITLE
fix: Prevent XRootD marking http/https queries as valid

### DIFF
--- a/snakemake_storage_plugin_xrootd/__init__.py
+++ b/snakemake_storage_plugin_xrootd/__init__.py
@@ -250,6 +250,10 @@ class StorageProvider(StorageProviderBase):
                 reason="Malformed XRootD url",
                 query=query,
             )
+        if url.protocol in ["http", "https"]:
+            return StorageQueryValidationResult(
+                valid=False, reason="Protocol cannot be http or https", query=query
+            )
         return StorageQueryValidationResult(valid=True, query=query)
 
     def postprocess_query(self, query: str) -> str:


### PR DESCRIPTION
XRootD considers queries using http or https protocol e.g. `http://google.com` as valid however this causes difficulties with the `snakemake-storage-plugin-http` when snakemake tries to automatically infer the storage provider.

This makes the checking of a query stricter by rejecting queries with a `http` or `https` protocol.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced URL validation for storage queries by disallowing HTTP/HTTPS protocols. Now, queries using these protocols will be flagged as invalid, ensuring that only appropriate query inputs are accepted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->