### PR TITLE
fix: Ensure query is tested rather than url

### DIFF
--- a/snakemake_storage_plugin_xrootd/__init__.py
+++ b/snakemake_storage_plugin_xrootd/__init__.py
@@ -246,7 +246,7 @@ class StorageProvider(StorageProviderBase):
         # object is actually used.
         url = URL(query)
         # XRootD URL.is_valid() is very permissive so regex to be safe
-        if not url.is_valid() or re.findall(r"((?:[A-Za-z]+://))(.+)", str(url)) == []:
+        if not url.is_valid() or re.findall(r"((?:[A-Za-z]+://))(.+)", query) == []:
             return StorageQueryValidationResult(
                 valid=False,
                 reason="Malformed XRootD url",


### PR DESCRIPTION
Fix typo when checking query -- should check the actual query itself rather than the url (as the url adds the `root://` which the regex is checking for...)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the query validation process to directly use the original input string instead of a processed version. This enhancement ensures a more precise and reliable assessment of query validity, potentially improving user interactions when submitting storage requests. The system now more accurately reflects intended query criteria, which can lead to better overall performance for storage operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->