### PR TITLE
feat: provide url decorator as python expression str, not function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ dependencies = [
   "snakemake-interface-common >=1.15.0,<2",
   "snakemake-interface-storage-plugins >=3,<4",
   "xrootd >=5.6,<6",
-  "snakemake >=8.18,<9"
 ]
 
 [project.urls]
@@ -48,3 +47,6 @@ test = { features = ["test"], solve-group = "default" }
 test = "pytest -vv tests/tests.py"
 test-coverage = "coverage run -m pytest -vv tests/tests.py"
 coverage-report = "coverage report"
+
+[tool.pixi.feature.test.dependencies]
+snakemake = ">=8.30.0,<9"

--- a/snakemake_storage_plugin_xrootd/__init__.py
+++ b/snakemake_storage_plugin_xrootd/__init__.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 import os
 import re
-from typing import Any, Iterable, Optional, List, Type, Callable
+from typing import Any, Iterable, Optional, List, Type
 
 from reretry import retry
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -58,4 +58,5 @@ class TestStorage(TestStorageBase):
         return StorageProviderSettings(
             host="localhost",
             port=XROOTD_TEST_PORT,
+            url_decorator="url + '?authz=anonymous'",
         )


### PR DESCRIPTION
Otherwise, it would not be specifiable via the command line

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a configurable URL decoration mechanism that enables dynamic URL modification using string expressions.
  
- **Tests**
	- Updated test configurations to include the new URL decoration parameter, ensuring proper validation of the enhanced URL handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->