### PR TITLE
fix!: Move URL decorator to use exec instead of eval

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,5 +48,5 @@ test = "pytest -vv tests/tests.py"
 test-coverage = "coverage run -m pytest -vv tests/tests.py"
 coverage-report = "coverage report"
 
-[tool.pixi.feature.test.dependencies]
-snakemake = ">=8.30.0,<9"
+[tool.pixi.feature.test.pypi-dependencies]
+snakemake = ">=9.0.1,<10"

--- a/snakemake_storage_plugin_xrootd/__init__.py
+++ b/snakemake_storage_plugin_xrootd/__init__.py
@@ -88,9 +88,10 @@ class StorageProviderSettings(StorageProviderSettingsBase):
         default=None,
         metadata={
             "help": (
-                "A Python expression (given as str) to decorate the URL (which is "
-                "available as variable `url` in the expression) e.g. to decorate it "
-                "with an auth token."
+                "Python code (given as str) to decorate the URL (which is "
+                "available as variable `url` which will run through `exec`"
+                "and must put the new URL in a variable `new_url`) e.g. to"
+                "decorate it with an auth token."
             ),
             "env_var": False,
             "required": False,
@@ -132,7 +133,9 @@ class StorageProvider(StorageProviderBase):
 
     def url_decorator(self, url: str) -> str:
         if self.settings.url_decorator is not None:
-            return eval(self.settings.url_decorator, {"url": url})
+            local_vars = {}
+            exec(self.settings.url_decorator, globals={"url": url}, locals=local_vars)
+            return local_vars["new_url"]
         return url
 
     def _check_status(self, status: XRootDStatus, error_preamble: str):


### PR DESCRIPTION
The URL decorator function can be quite complicated (at least in my use-case) and is difficult to wrap into an expression that can be used in `eval`.

This PR changes instead to an `exec` statement, that expects the new URL to be written to a variable `new_url`.

Additionally, the snakemake version used in the tests is bumped to `>=9.0.1` and this is temporarily moved to be a PyPi dependency as snakemake 9.0.1 is not yet availble in conda.