### PR TITLE
feat: add XRootD protocol preference support

### DIFF
--- a/docs/further.md
+++ b/docs/further.md
@@ -1,5 +1,9 @@
 The `username` and `password` fields do not need to be specified if you use `kerberos` and/or a VOMS proxy for authentication.
 
+The optional `protocol` setting can be used to pass a preferred XRootD authentication protocol list to the client, for example `krb5` or `krb5,unix`. This is useful for setups where relying on external `XrdSecPROTOCOL` forwarding would be fragile.
+
 The optional `url_decorator` argument can be used to pass a function to modify the root URL.
 
 A possible use-case would be a function that wraps the URL with a token to allow for authentication.
+
+If both `protocol` and `url_decorator` are used, the plugin adds the `xrd.wantprot` query parameter first and then applies the decorator. Decorators therefore need to handle URLs that may already contain query parameters.

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -4,6 +4,8 @@ Currently, only files can be used as inputs or outputs and not directories.
 
 The plugin can be used without specifying any options relating to the URLs, in which case all information must be contained in the URL passed by the user.
 
-The options for `host`, `port`, `username`, `password` and `url_decorator` can be specifed to make the URLs shorter and easier to use.
+The options for `host`, `port`, `username`, `password`, `protocol`, and `url_decorator` can be specified to make the URLs shorter and easier to use.
 
 Please note: if the `password` option is supplied (even implicitly via the environment variable `SNAKEMAKE_STORAGE_XROOTD_PASSWORD`) it will be displayed in plaintext as part of the XRootD URLs when Snakemake prints information about a rule. Only use the `password` option in trusted environments.
+
+The optional `protocol` setting can be used to set the preferred XRootD authentication protocol order directly in the provider configuration. The value is passed through to XRootD unchanged, so comma-separated values such as `krb5,unix` are supported.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 dependencies = [
   "snakemake-interface-common >=1.15.0,<2",
   "snakemake-interface-storage-plugins >=4.1.0,<5",
+  "reretry >=0.11.8,<0.12",
   "xrootd >=5.6,<6",
 ]
 

--- a/snakemake_storage_plugin_xrootd/__init__.py
+++ b/snakemake_storage_plugin_xrootd/__init__.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, field
 import os
 import re
+from urllib.parse import quote
 from typing import Any, Iterable, Optional, List, Type
 import importlib
 
@@ -82,6 +83,18 @@ class StorageProviderSettings(StorageProviderSettingsBase):
             "password in plaintext as part of the XRootD URLs used in the "
             "inputs/outputs of jobs.",
             "env_var": True,
+            "required": False,
+        },
+    )
+    protocol: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": (
+                "Preferred XRootD authentication protocol(s), passed through "
+                "to the client unchanged. Comma-separated values such as "
+                "'krb5,unix' are allowed."
+            ),
+            "env_var": False,
             "required": False,
         },
     )
@@ -223,6 +236,11 @@ class StorageProvider(StorageProviderBase):
     def _safe_to_print_url(url: str) -> str:
         return StorageProvider._no_params_url(StorageProvider._no_pass_url(url))
 
+    @staticmethod
+    def _append_query_param(url: str, key: str, value: str) -> str:
+        sep = "&" if "?" in url else "?"
+        return f"{url}{sep}{key}={quote(value, safe=',')}"
+
     def _parse_url(self, query: str) -> List[str] | None:
         url = URL(query)
         user = self.username or url.username
@@ -250,6 +268,10 @@ class StorageProvider(StorageProviderBase):
         else:
             full_path = url.path_with_params
         new_url = f"{url.protocol}://{user_pass}{host}:{port}/{full_path}"
+        if self.settings.protocol:
+            new_url = self._append_query_param(
+                new_url, "xrd.wantprot", self.settings.protocol
+            )
         dec_url = self.url_decorator(new_url)
         full_url = URL(dec_url)
         if not full_url.is_valid():
@@ -316,7 +338,7 @@ class StorageObject(StorageObjectRead, StorageObjectWrite):
         # Does is_valid_query happen before this or we need to verify here too?
         self.url, self.dirname, self.filename = self.provider._parse_url(self.query)
         self.path = self.url.path
-        self.file_system = client.FileSystem(self.url.hostid)
+        self.file_system = client.FileSystem(str(self.url))
 
     # TODO
     async def inventory(self, cache: IOCacheStorageInterface):

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,3 +1,9 @@
 # decorator must be a string with an importable function so put one here
 def add_decorator(url: str) -> str:
     return url + "?authz=anonymous"
+
+
+def add_query_aware_decorator(url: str) -> str:
+    marker = "saw_query=yes" if "?" in url else "saw_query=no"
+    sep = "&" if "?" in url else "?"
+    return url + f"{sep}{marker}"

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,8 +1,10 @@
 import subprocess
 import time
+from pathlib import Path
 from typing import Optional, Type
 
 import pytest
+from snakemake_interface_common.logging import get_logger
 from snakemake_interface_storage_plugins.tests import TestStorageBase
 from snakemake_interface_storage_plugins.storage_provider import StorageProviderBase
 from snakemake_interface_storage_plugins.settings import StorageProviderSettingsBase
@@ -11,6 +13,16 @@ from snakemake_storage_plugin_xrootd import StorageProvider, StorageProviderSett
 import socket
 
 XROOTD_TEST_PORT = 32293
+
+
+def make_provider(settings: StorageProviderSettings) -> StorageProvider:
+    return StorageProvider(
+        local_prefix=Path(".tests-local"),
+        logger=get_logger(),
+        settings=settings,
+        keep_local=False,
+        is_default=False,
+    )
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -83,3 +95,49 @@ class TestStorageEval(TestStorageBase):
             port=XROOTD_TEST_PORT,
             url_decorator="url + '?authz=anonymous'",
         )
+
+
+def test_postprocess_query_adds_protocol_preference():
+    provider = make_provider(StorageProviderSettings(protocol="krb5"))
+
+    query = provider.postprocess_query("root://host//test.txt")
+
+    assert query == "root://host:1094//test.txt?xrd.wantprot=krb5"
+
+
+def test_postprocess_query_supports_multiple_protocols():
+    provider = make_provider(StorageProviderSettings(protocol="krb5,unix"))
+
+    query = provider.postprocess_query("root://host//test.txt")
+
+    assert query == "root://host:1094//test.txt?xrd.wantprot=krb5,unix"
+
+
+def test_postprocess_query_preserves_existing_params():
+    provider = make_provider(StorageProviderSettings(protocol="krb5,unix"))
+
+    query = provider.postprocess_query("root://host//test.txt?authz=anonymous")
+
+    assert query == "root://host:1094//test.txt?authz=anonymous&xrd.wantprot=krb5,unix"
+
+
+def test_protocol_is_added_before_url_decorator():
+    provider = make_provider(
+        StorageProviderSettings(
+            protocol="krb5,unix",
+            url_decorator="test_decorators:add_query_aware_decorator",
+        )
+    )
+
+    query = provider.postprocess_query("root://host//test.txt")
+
+    assert "xrd.wantprot=krb5,unix" in query
+    assert "saw_query=yes" in query
+
+
+def test_safe_print_redacts_protocol_query_param():
+    provider = make_provider(StorageProviderSettings(protocol="krb5,unix"))
+
+    query = provider.postprocess_query("root://host//test.txt")
+
+    assert provider.safe_print(query) == "root://host:1094//test.txt?****"


### PR DESCRIPTION
For CMS open data access, I have to explicitly set `XrdSecPROTOCOL=krb5,unix`, otherwise XrootD will try to use my grid certificate, which breaks the workflow. While this works when prepending to Snakemake commands in general, it fails for me e.g. when using Apptainer (or at least I'd have to set this in several places and remember to do so). With this PR, I'm adding an optional `protocol` setting that is passed through to XRootD via `xrd.wantprot`, so users can configure values such as `krb5` or `krb5,unix` in the storage provider instead of relying on external `XrdSecPROTOCOL` forwarding.

The change also makes metadata operations construct `FileSystem` from the full URL so the same query parameters are preserved consistently across both metadata and transfer code paths.

I also found that the `reretry` dependency wasn't in `pyproject.toml`, so I added it.

## More detailed changes

  - add optional `protocol` to `StorageProviderSettings`
  - append `xrd.wantprot=<value>` to the effective URL in `_parse_url()`
  - construct `client.FileSystem(...)` from the full URL instead of `hostid`
  - add tests for:
    - single protocol values
    - comma-separated protocol values
    - preserving existing query parameters
    - composition with `url_decorator`
    - `safe_print()` redaction
  - document the new setting in `docs/intro.md` and `docs/further.md`
  - declare the existing `reretry` runtime dependency in `pyproject.toml` so the plugin imports cleanly in a fresh environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `protocol` configuration option to specify preferred XRootD authentication protocols (e.g., `krb5` or `krb5,unix`).

* **Documentation**
  * Updated configuration documentation to include the new `protocol` option and its interaction with existing URL-related settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->