### PR TITLE
fix: Rename 'Source code' to 'Repository' in project.urls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 dependencies = [
   "snakemake-interface-common >=1.15.0,<2",
   "snakemake-interface-storage-plugins >=4.1.0,<5",
+  "reretry >=0.11.8,<0.12",
   "xrootd >=5.6,<6",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
 ]
 
 [project.urls]
-"Source code" = "https://github.com/snakemake/snakemake-storage-plugin-xrootd"
+Repository = "https://github.com/snakemake/snakemake-storage-plugin-xrootd"
 Documentation = "https://snakemake.github.io/snakemake-plugin-catalog/plugins/storage/xrootd.html"
 
 [build-system]


### PR DESCRIPTION
The warning at https://snakemake.github.io/snakemake-plugin-catalog/plugins/storage/xrootd.html says:

```
No repository URL found in Pypi metadata. The plugin should specify a repository URL in its pyproject.toml (key 'repository'). It is unclear whether the plugin is maintained and reviewed by the official Snakemake organization (https://github.com/snakemake).
```

This should address this. Also adding the `reretry` dependency (already in #45) since tests fail without it.

Closes #11 