### PR TITLE
chore: Bump xrootd version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
   "snakemake-interface-common >=1.15.0,<2",
   "snakemake-interface-storage-plugins >=4.1.0,<5",
   "reretry >=0.11.8,<0.12",
-  "xrootd >=5.6,<6",
+  "xrootd >=5.6,<7",
 ]
 
 [project.urls]
@@ -35,7 +35,7 @@ channels = ["conda-forge", "bioconda"]
 platforms = ["linux-64", "osx-arm64", "osx-64"]
 
 [tool.pixi.dependencies]
-xrootd = ">=5.7.3,<6"
+xrootd = ">=5.7.3,<7"
 
 [tool.pixi.pypi-dependencies]
 snakemake-storage-plugin-xrootd = { path = ".", editable = true }


### PR DESCRIPTION
XRootD version 6 has released (https://github.com/xrootd/xrootd/releases/tag/v6.0.0), a quick local check with this still seems to run fine so adjust the max version number from `<6` to `<7`. Closes https://github.com/snakemake/snakemake-storage-plugin-xrootd/issues/48