### PR TITLE
feat: Implement `list_candidate_matches`

### DIFF
--- a/snakemake_storage_plugin_xrootd/__init__.py
+++ b/snakemake_storage_plugin_xrootd/__init__.py
@@ -118,7 +118,7 @@ class StorageProviderSettings(StorageProviderSettingsBase):
         default=100,
         metadata={
             "help": (
-                "Maximum directory nesting depth when calling `glob_wildcards`."
+                "Maximum directory nesting depth when calling `glob_wildcards`. "
                 "Guards against symlink loops or misbehaving servers causing "
                 "unbounded recursion."
             ),
@@ -372,7 +372,7 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
     def get_inventory_parent(self) -> Optional[str]:
         """Return the parent directory of this object."""
         # this is optional and can be left as is
-        return str(self.url).replace(self.filename, "")
+        return self._url_with_new_path(str(self.url), self.dirname)
 
     def local_suffix(self) -> str:
         """Return a unique suffix for the local path, determined from self.query."""
@@ -388,23 +388,10 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
 
     @xrootd_retry
     def exists(self) -> bool:
-        return self._exists(self.query)
+        return self._exists(self.url.path_with_params)
 
-    def _exists(self, query) -> bool:
-        # we split up the query again so that this can be re-used to check the
-        # existence of other files e.g. the parent directory.
-        url, dirname, filename = self.provider._parse_url(query)
-        status, stat_info = self.file_system.stat(url.path_with_params)
-        # a bit special, 3011 == file not found
-        if not status.ok:
-            if status.errno == 3011:
-                return False
-            self.provider._check_status(
-                status,
-                "Error checking existence of "
-                f"{self.provider._safe_to_print_url(query)} on XRootD",
-            )
-        return True
+    def _exists(self, path_with_params: str) -> bool:
+        return self._stat(path_with_params, allow_missing=True) is not None
 
     def mtime(self) -> float:
         # return the modification time
@@ -417,8 +404,13 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
         return stat.size
 
     @xrootd_retry
-    def _stat(self, path_with_params: str) -> StatInfo:
+    def _stat(
+        self, path_with_params: str, allow_missing: bool = False
+    ) -> Optional[StatInfo]:
         status, stat_info = self.file_system.stat(path_with_params)
+        # 3011==file not found is in the no_retry_codes list, so we need to handle it here
+        if allow_missing and not status.ok and status.errno == 3011:
+            return None
         self.provider._check_status(
             status,
             f"Error checking info of {self.provider._safe_to_print_url(self.query)}",
@@ -452,7 +444,7 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
 
     @xrootd_retry
     def _makedirs(self):
-        if not self._exists(self.get_inventory_parent()):
+        if not self._exists(URL(self.get_inventory_parent()).path_with_params):
             status, _ = self.file_system.mkdir(self.dirname, MkDirFlags.MAKEPATH)
             self.provider._check_status(
                 status,
@@ -500,9 +492,8 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
         # The method has to return concretized queries without any remaining wildcards.
         # Use snakemake_executor_plugins.io.get_constant_prefix(self.query) to get the
         # prefix of the query before the first wildcard.
-        url, _, _ = self.provider._parse_url(self.query)
-        const_prefix = get_constant_prefix(url.path, strip_incomplete_parts=True)
-        glob_query = self._url_with_new_path(str(url), const_prefix)
+        const_prefix = get_constant_prefix(self.url.path, strip_incomplete_parts=True)
+        glob_query = self._url_with_new_path(str(self.url), const_prefix)
         yield from self._list_recursive(glob_query)
 
     @staticmethod
@@ -541,7 +532,10 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
         # return it directly. (Only need to do this for the first call, since we check
         # it before recursing into subdirectories.)
         if _depth == 0:
-            stat_info = self._stat(url.path_with_params)
+            stat_info = self._stat(url.path_with_params, allow_missing=True)
+            # Prefix does not exist, return nothing.
+            if stat_info is None:
+                return
             if not stat_info.flags & StatInfoFlags.IS_DIR:
                 yield query
                 return

--- a/snakemake_storage_plugin_xrootd/__init__.py
+++ b/snakemake_storage_plugin_xrootd/__init__.py
@@ -503,10 +503,23 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
         # prefix of the query before the first wildcard.
         url, _, _ = self.provider._parse_url(self.query)
         const_prefix = os.path.split(get_constant_prefix(url.path))[0]
-        glob_query = str(url).replace(url.path, const_prefix)
+        glob_query = self._url_with_new_path(str(url), const_prefix)
         return self._list_recursive(glob_query)
 
-    @xrootd_retry
+    @staticmethod
+    def _url_with_new_path(url: str, new_path: str) -> str:
+        parsed = URL(url)
+        parsed_params = parsed.path_with_params[len(parsed.path) :]
+
+        new_url = (
+            parsed.protocol + "://" + parsed.hostid + "/" + new_path + parsed_params
+        )
+        if not URL(new_url).is_valid():
+            raise WorkflowError(
+                f"XRootD Error: URL {StorageProvider._safe_to_print_url(new_url)} is invalid"
+            )
+        return new_url
+
     def _list_recursive(self, query: str, _depth: int = 0) -> Iterable[str]:
         if _depth > self.provider.settings.glob_wildcards_max_depth:
             raise XRootDFatalException(
@@ -554,8 +567,8 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
                 )
                 continue
 
-            child_query = query.replace(
-                url.path, url.path.rstrip("/") + "/" + entry.name
+            child_query = self._url_with_new_path(
+                str(url), url.path.rstrip("/") + "/" + entry.name
             )
             if (
                 entry.statinfo is not None

--- a/snakemake_storage_plugin_xrootd/__init__.py
+++ b/snakemake_storage_plugin_xrootd/__init__.py
@@ -9,7 +9,7 @@ from reretry import retry
 
 from XRootD import client
 from XRootD.client.flags import DirListFlags, MkDirFlags, StatInfoFlags
-from XRootD.client.responses import XRootDStatus
+from XRootD.client.responses import XRootDStatus, StatInfo, DirectoryList
 from XRootD.client import URL
 
 from snakemake.exceptions import WorkflowError
@@ -406,25 +406,24 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
             )
         return True
 
-    @xrootd_retry
     def mtime(self) -> float:
         # return the modification time
-        status, stat = self.file_system.stat(self.url.path_with_params)
-        self.provider._check_status(
-            status,
-            f"Error checking info of {self.provider._safe_to_print_url(self.query)}",
-        )
+        stat = self._stat(self.url.path_with_params)
         return stat.modtime
 
-    @xrootd_retry
     def size(self) -> int:
         # return the size in bytes
-        status, stat = self.file_system.stat(self.url.path_with_params)
+        stat = self._stat(self.url.path_with_params)
+        return stat.size
+
+    @xrootd_retry
+    def _stat(self, path_with_params: str) -> StatInfo:
+        status, stat_info = self.file_system.stat(path_with_params)
         self.provider._check_status(
             status,
             f"Error checking info of {self.provider._safe_to_print_url(self.query)}",
         )
-        return stat.size
+        return stat_info
 
     @xrootd_retry
     def retrieve_object(self):
@@ -482,19 +481,19 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
     @xrootd_retry
     def remove(self):
         # Remove the object from the storage.
-        status, stat = self.file_system.stat(self.path)
-        self.provider._check_status(status, f"Error could not stat {self.path}")
+        stat = self._stat(self.url.path_with_params)
         if stat.flags & StatInfoFlags.IS_DIR:
             rm_func = self.file_system.rmdir
         else:
             rm_func = self.file_system.rm
-        status, _ = rm_func(self.path)
-        self.provider._check_status(status, f"Error removing {self.path}")
+        status, _ = rm_func(self.url.path_with_params)
+        self.provider._check_status(
+            status, f"Error removing {self.provider._safe_to_print_url(self.query)}"
+        )
 
     # The following to methods are only required if the class inherits from
     # StorageObjectGlob.
 
-    @xrootd_retry
     def list_candidate_matches(self) -> Iterable[str]:
         """Return a list of candidate matches in the storage for the query."""
         # This is used by glob_wildcards() to find matches for wildcards in the query.
@@ -504,7 +503,7 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
         url, _, _ = self.provider._parse_url(self.query)
         const_prefix = os.path.split(get_constant_prefix(url.path))[0]
         glob_query = self._url_with_new_path(str(url), const_prefix)
-        return self._list_recursive(glob_query)
+        yield from self._list_recursive(glob_query)
 
     @staticmethod
     def _url_with_new_path(url: str, new_path: str) -> str:
@@ -520,9 +519,18 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
             )
         return new_url
 
+    @xrootd_retry
+    def _dirlist(self, path_with_params: str) -> DirectoryList:
+        status, dirlist = self.file_system.dirlist(path_with_params, DirListFlags.STAT)
+        self.provider._check_status(
+            status,
+            f"Error listing directory {self.provider._safe_to_print_url(self.query)}",
+        )
+        return dirlist
+
     def _list_recursive(self, query: str, _depth: int = 0) -> Iterable[str]:
         if _depth > self.provider.settings.glob_wildcards_max_depth:
-            raise XRootDFatalException(
+            raise WorkflowError(
                 "XRootD Error: directory nesting exceeds maximum depth of "
                 f"{self.provider.settings.glob_wildcards_max_depth} while listing "
                 f"{self.provider._safe_to_print_url(query)}"
@@ -533,24 +541,13 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
         # return it directly. (Only need to do this for the first call, since we check
         # it before recursing into subdirectories.)
         if _depth == 0:
-            stat_status, stat_info = self.file_system.stat(url.path_with_params)
-            self.provider._check_status(
-                stat_status,
-                f"Error checking info of {self.provider._safe_to_print_url(query)}",
-            )
+            stat_info = self._stat(url.path_with_params)
             if not stat_info.flags & StatInfoFlags.IS_DIR:
-                return [query]
+                yield query
+                return
 
-        status, dirlist = self.file_system.dirlist(
-            url.path_with_params, DirListFlags.STAT
-        )
+        dirlist = self._dirlist(url.path_with_params)
 
-        self.provider._check_status(
-            status,
-            f"Error listing directory {self.provider._safe_to_print_url(query)}",
-        )
-
-        matches = []
         for entry in dirlist.dirlist:
             # Dirlist should never return entries with empty names or "." or ".." or
             # names containing slashes, but we check for that anyway to be safe.
@@ -574,7 +571,6 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
                 entry.statinfo is not None
                 and entry.statinfo.flags & StatInfoFlags.IS_DIR
             ):
-                matches.extend(self._list_recursive(child_query, _depth + 1))
+                yield from self._list_recursive(child_query, _depth + 1)
             else:
-                matches.append(child_query)
-        return matches
+                yield child_query

--- a/snakemake_storage_plugin_xrootd/__init__.py
+++ b/snakemake_storage_plugin_xrootd/__init__.py
@@ -8,7 +8,7 @@ import importlib
 from reretry import retry
 
 from XRootD import client
-from XRootD.client.flags import MkDirFlags, StatInfoFlags
+from XRootD.client.flags import DirListFlags, MkDirFlags, StatInfoFlags
 from XRootD.client.responses import XRootDStatus
 from XRootD.client import URL
 
@@ -26,9 +26,12 @@ from snakemake_interface_storage_plugins.storage_provider import (  # noqa: F401
 from snakemake_interface_storage_plugins.storage_object import (
     StorageObjectRead,
     StorageObjectWrite,
-    retry_decorator,
+    StorageObjectGlob,
 )
-from snakemake_interface_storage_plugins.io import IOCacheStorageInterface
+from snakemake_interface_storage_plugins.io import (
+    IOCacheStorageInterface,
+    get_constant_prefix,
+)
 
 
 class XRootDFatalException(Exception):
@@ -106,6 +109,18 @@ class StorageProviderSettings(StorageProviderSettingsBase):
                 "expression (e.g. 'url + \"?foo=bar\"') that decorates the URL. "
                 "Function expects a single string argument (URL) and returns "
                 "the decorated URL. Expression has 'url' available."
+            ),
+            "env_var": False,
+            "required": False,
+        },
+    )
+    glob_wildcards_max_depth: int = field(
+        default=100,
+        metadata={
+            "help": (
+                "Maximum directory nesting depth when calling `glob_wildcards`."
+                "Guards against symlink loops or misbehaving servers causing "
+                "unbounded recursion."
             ),
             "env_var": False,
             "required": False,
@@ -329,7 +344,7 @@ class StorageProvider(StorageProviderBase):
 # storage (e.g. because it is read-only see
 # snakemake-storage-http for comparison), remove the corresponding base classes
 # from the list of inherited items.
-class StorageObject(StorageObjectRead, StorageObjectWrite):
+class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
     # For compatibility with future changes, you should not overwrite the __init__
     # method. Instead, use __post_init__ to set additional attributes and initialize
     # futher stuff.
@@ -479,13 +494,74 @@ class StorageObject(StorageObjectRead, StorageObjectWrite):
     # The following to methods are only required if the class inherits from
     # StorageObjectGlob.
 
-    # TODO
-    @retry_decorator
+    @xrootd_retry
     def list_candidate_matches(self) -> Iterable[str]:
         """Return a list of candidate matches in the storage for the query."""
         # This is used by glob_wildcards() to find matches for wildcards in the query.
         # The method has to return concretized queries without any remaining wildcards.
         # Use snakemake_executor_plugins.io.get_constant_prefix(self.query) to get the
         # prefix of the query before the first wildcard.
-        # TODO add support for listing files here
-        raise NotImplementedError()
+        url, _, _ = self.provider._parse_url(self.query)
+        const_prefix = os.path.split(get_constant_prefix(url.path))[0]
+        glob_query = str(url).replace(url.path, const_prefix)
+        return self._list_recursive(glob_query)
+
+    @xrootd_retry
+    def _list_recursive(self, query: str, _depth: int = 0) -> Iterable[str]:
+        if _depth > self.provider.settings.glob_wildcards_max_depth:
+            raise XRootDFatalException(
+                "XRootD Error: directory nesting exceeds maximum depth of "
+                f"{self.provider.settings.glob_wildcards_max_depth} while listing "
+                f"{self.provider._safe_to_print_url(query)}"
+            )
+
+        url = URL(query)
+        # First check if the path is a directory or a file. If it is a file, we can
+        # return it directly. (Only need to do this for the first call, since we check
+        # it before recursing into subdirectories.)
+        if _depth == 0:
+            stat_status, stat_info = self.file_system.stat(url.path_with_params)
+            self.provider._check_status(
+                stat_status,
+                f"Error checking info of {self.provider._safe_to_print_url(query)}",
+            )
+            if not stat_info.flags & StatInfoFlags.IS_DIR:
+                return [query]
+
+        status, dirlist = self.file_system.dirlist(
+            url.path_with_params, DirListFlags.STAT
+        )
+
+        self.provider._check_status(
+            status,
+            f"Error listing directory {self.provider._safe_to_print_url(query)}",
+        )
+
+        matches = []
+        for entry in dirlist.dirlist:
+            # Dirlist should never return entries with empty names or "." or ".." or
+            # names containing slashes, but we check for that anyway to be safe.
+            if (
+                not entry.name
+                or entry.name in (".", "..")
+                or "/" in entry.name
+                or "\\" in entry.name
+            ):
+                get_logger().warning(
+                    "Skipping suspicious directory entry name "
+                    f"{entry.name!r} returned while listing "
+                    f"{self.provider._safe_to_print_url(query)}"
+                )
+                continue
+
+            child_query = query.replace(
+                url.path, url.path.rstrip("/") + "/" + entry.name
+            )
+            if (
+                entry.statinfo is not None
+                and entry.statinfo.flags & StatInfoFlags.IS_DIR
+            ):
+                matches.extend(self._list_recursive(child_query, _depth + 1))
+            else:
+                matches.append(child_query)
+        return matches

--- a/snakemake_storage_plugin_xrootd/__init__.py
+++ b/snakemake_storage_plugin_xrootd/__init__.py
@@ -501,7 +501,7 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
         # Use snakemake_executor_plugins.io.get_constant_prefix(self.query) to get the
         # prefix of the query before the first wildcard.
         url, _, _ = self.provider._parse_url(self.query)
-        const_prefix = os.path.split(get_constant_prefix(url.path))[0]
+        const_prefix = get_constant_prefix(url.path, strip_incomplete_parts=True)
         glob_query = self._url_with_new_path(str(url), const_prefix)
         yield from self._list_recursive(glob_query)
 

--- a/snakemake_storage_plugin_xrootd/__init__.py
+++ b/snakemake_storage_plugin_xrootd/__init__.py
@@ -355,6 +355,56 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
         self.path = self.url.path
         self.file_system = client.FileSystem(str(self.url))
 
+    @xrootd_retry
+    def _stat(
+        self, path_with_params: str, allow_missing: bool = False
+    ) -> Optional[StatInfo]:
+        status, stat_info = self.file_system.stat(path_with_params)
+        # 3011==file not found is in the no_retry_codes list, so we need to handle it here
+        if allow_missing and not status.ok and status.errno == 3011:
+            return None
+        self.provider._check_status(
+            status,
+            f"Error checking info of {self.provider._safe_to_print_url(self.query)}",
+        )
+        return stat_info
+
+    def _exists(self, path_with_params: str) -> bool:
+        return self._stat(path_with_params, allow_missing=True) is not None
+
+    @xrootd_retry
+    def _makedirs(self):
+        if not self._exists(URL(self.get_inventory_parent()).path_with_params):
+            status, _ = self.file_system.mkdir(self.dirname, MkDirFlags.MAKEPATH)
+            self.provider._check_status(
+                status,
+                "Error creating directory "
+                f"{self.provider._safe_to_print_url(self.query)}",
+            )
+
+    @staticmethod
+    def _url_with_new_path(url: str, new_path: str) -> str:
+        parsed = URL(url)
+        parsed_params = parsed.path_with_params[len(parsed.path) :]
+
+        new_url = (
+            parsed.protocol + "://" + parsed.hostid + "/" + new_path + parsed_params
+        )
+        if not URL(new_url).is_valid():
+            raise WorkflowError(
+                f"XRootD Error: URL {StorageProvider._safe_to_print_url(new_url)} is invalid"
+            )
+        return new_url
+
+    @xrootd_retry
+    def _dirlist(self, path_with_params: str) -> DirectoryList:
+        status, dirlist = self.file_system.dirlist(path_with_params, DirListFlags.STAT)
+        self.provider._check_status(
+            status,
+            f"Error listing directory {self.provider._safe_to_print_url(self.query)}",
+        )
+        return dirlist
+
     # TODO
     async def inventory(self, cache: IOCacheStorageInterface):
         """From this file, try to find as much existence and modification date
@@ -386,12 +436,8 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
         # Snakemake.
         pass
 
-    @xrootd_retry
     def exists(self) -> bool:
         return self._exists(self.url.path_with_params)
-
-    def _exists(self, path_with_params: str) -> bool:
-        return self._stat(path_with_params, allow_missing=True) is not None
 
     def mtime(self) -> float:
         # return the modification time
@@ -402,20 +448,6 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
         # return the size in bytes
         stat = self._stat(self.url.path_with_params)
         return stat.size
-
-    @xrootd_retry
-    def _stat(
-        self, path_with_params: str, allow_missing: bool = False
-    ) -> Optional[StatInfo]:
-        status, stat_info = self.file_system.stat(path_with_params)
-        # 3011==file not found is in the no_retry_codes list, so we need to handle it here
-        if allow_missing and not status.ok and status.errno == 3011:
-            return None
-        self.provider._check_status(
-            status,
-            f"Error checking info of {self.provider._safe_to_print_url(self.query)}",
-        )
-        return stat_info
 
     @xrootd_retry
     def retrieve_object(self):
@@ -441,16 +473,6 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
 
     # The following to methods are only required if the class inherits from
     # StorageObjectReadWrite.
-
-    @xrootd_retry
-    def _makedirs(self):
-        if not self._exists(URL(self.get_inventory_parent()).path_with_params):
-            status, _ = self.file_system.mkdir(self.dirname, MkDirFlags.MAKEPATH)
-            self.provider._check_status(
-                status,
-                "Error creating directory "
-                f"{self.provider._safe_to_print_url(self.query)}",
-            )
 
     @xrootd_retry
     def store_object(self):
@@ -495,29 +517,6 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
         const_prefix = get_constant_prefix(self.url.path, strip_incomplete_parts=True)
         glob_query = self._url_with_new_path(str(self.url), const_prefix)
         yield from self._list_recursive(glob_query)
-
-    @staticmethod
-    def _url_with_new_path(url: str, new_path: str) -> str:
-        parsed = URL(url)
-        parsed_params = parsed.path_with_params[len(parsed.path) :]
-
-        new_url = (
-            parsed.protocol + "://" + parsed.hostid + "/" + new_path + parsed_params
-        )
-        if not URL(new_url).is_valid():
-            raise WorkflowError(
-                f"XRootD Error: URL {StorageProvider._safe_to_print_url(new_url)} is invalid"
-            )
-        return new_url
-
-    @xrootd_retry
-    def _dirlist(self, path_with_params: str) -> DirectoryList:
-        status, dirlist = self.file_system.dirlist(path_with_params, DirListFlags.STAT)
-        self.provider._check_status(
-            status,
-            f"Error listing directory {self.provider._safe_to_print_url(self.query)}",
-        )
-        return dirlist
 
     def _list_recursive(self, query: str, _depth: int = 0) -> Iterable[str]:
         if _depth > self.provider.settings.glob_wildcards_max_depth:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Optional, Type
 
 import pytest
+from snakemake.exceptions import WorkflowError
 from snakemake_interface_common.logging import get_logger
 from snakemake_interface_storage_plugins.tests import TestStorageBase
 from snakemake_interface_storage_plugins.storage_provider import StorageProviderBase
@@ -12,7 +13,6 @@ from snakemake_interface_storage_plugins.settings import StorageProviderSettings
 from snakemake_storage_plugin_xrootd import (
     StorageProvider,
     StorageProviderSettings,
-    XRootDFatalException,
 )
 import socket
 
@@ -186,5 +186,5 @@ def test_list_candidate_matches_respects_depth_limit(start_xrootd_server, tmp_pa
     query = f"root://localhost:{start_xrootd_server}/{tmp_path}/{{name}}.txt"
     obj = provider.object(query=query, keep_local=False, retrieve=False)
 
-    with pytest.raises(XRootDFatalException):
+    with pytest.raises(WorkflowError):
         list(obj.list_candidate_matches())

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -9,7 +9,11 @@ from snakemake_interface_storage_plugins.tests import TestStorageBase
 from snakemake_interface_storage_plugins.storage_provider import StorageProviderBase
 from snakemake_interface_storage_plugins.settings import StorageProviderSettingsBase
 
-from snakemake_storage_plugin_xrootd import StorageProvider, StorageProviderSettings
+from snakemake_storage_plugin_xrootd import (
+    StorageProvider,
+    StorageProviderSettings,
+    XRootDFatalException,
+)
 import socket
 
 XROOTD_TEST_PORT = 32293
@@ -141,3 +145,46 @@ def test_safe_print_redacts_protocol_query_param():
     query = provider.postprocess_query("root://host//test.txt")
 
     assert provider.safe_print(query) == "root://host:1094//test.txt?****"
+
+
+def test_list_candidate_matches_recursive(start_xrootd_server, tmp_path):
+    provider = make_provider(
+        StorageProviderSettings(host="localhost", port=start_xrootd_server)
+    )
+
+    base = tmp_path / "glob_test"
+    (base / "sub").mkdir(parents=True)
+    (base / "a.txt").write_text("a")
+    (base / "b.txt").write_text("b")
+    (base / "sub" / "c.txt").write_text("c")
+
+    query = f"root://localhost:{start_xrootd_server}/{base}/{{name}}.txt"
+    obj = provider.object(query=query, keep_local=False, retrieve=False)
+
+    matches = list(obj.list_candidate_matches())
+
+    assert any(m.endswith("/a.txt") for m in matches)
+    assert any(m.endswith("/b.txt") for m in matches)
+    assert any(m.endswith("/sub/c.txt") for m in matches)
+    assert len(matches) == 3
+
+
+def test_list_candidate_matches_respects_depth_limit(start_xrootd_server, tmp_path):
+    provider = make_provider(
+        StorageProviderSettings(
+            host="localhost", port=start_xrootd_server, glob_wildcards_max_depth=2
+        )
+    )
+
+    # Build a directory chain deeper than the configured max depth.
+    deep = tmp_path
+    for i in range(5):
+        deep = deep / f"d{i}"
+    deep.mkdir(parents=True)
+    (deep / "leaf.txt").write_text("leaf")
+
+    query = f"root://localhost:{start_xrootd_server}/{tmp_path}/{{name}}.txt"
+    obj = provider.object(query=query, keep_local=False, retrieve=False)
+
+    with pytest.raises(XRootDFatalException):
+        list(obj.list_candidate_matches())


### PR DESCRIPTION
Extends `StorageObject` to inherit from `StorageObjectGlob` and implements the `list_candidate_matches` method to allow using `glob_wildcards` for xrootd storage objects.

Added local tests which work as intended, and I also tested it for a remote on CERN EOS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled `glob_wildcards()` for XRootD storage paths with recursive wildcard expansion.
  * Added `glob_wildcards_max_depth` to cap how deep wildcard resolution can traverse directories.
* **Bug Fixes**
  * Improved wildcard candidate matching by properly enumerating directory contents and handling non-directory targets safely.
  * Enhanced metadata and deletion behavior for more consistent results and clearer error messages.
* **Tests**
  * Added integration tests covering recursive wildcard matching and verification that the depth limit triggers the expected workflow error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->